### PR TITLE
Support zero for the maximum of vscale_range

### DIFF
--- a/test/llvm_ir_correct/vscale-mbits.f90
+++ b/test/llvm_ir_correct/vscale-mbits.f90
@@ -7,9 +7,13 @@
 ! REQUIRES: llvm-13
 
 ! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve -msve-vector-bits=128 %s -o - | FileCheck %s -check-prefix=ATTRS-SVE-128
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve -msve-vector-bits=128+ %s -o - | FileCheck %s -check-prefix=ATTRS-SVE-128+
 ! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve -msve-vector-bits=256 %s -o - | FileCheck %s -check-prefix=ATTRS-SVE-256
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve -msve-vector-bits=256+ %s -o - | FileCheck %s -check-prefix=ATTRS-SVE-256+
 ! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2 -msve-vector-bits=512 %s -o - | FileCheck %s -check-prefix=ATTRS-SVE2-512
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2 -msve-vector-bits=512+ %s -o - | FileCheck %s -check-prefix=ATTRS-SVE2-512+
 ! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2-sha3 -msve-vector-bits=2048 %s -o - | FileCheck %s -check-prefix=ATTRS-SVE2SHA3-2048
+! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2-sha3 -msve-vector-bits=2048+ %s -o - | FileCheck %s -check-prefix=ATTRS-SVE2SHA3-2048+
 ! RUN: %flang -S -emit-llvm -target aarch64-linux-gnu -march=armv8-a+sve2 -msve-vector-bits=scalable %s -o - | FileCheck %s -check-prefix=ATTRS-SVE2-SCALABLE
       program tz
        integer :: i
@@ -22,15 +26,27 @@
 ! ATTRS-SVE-128: attributes #{{[0-9]+}}
 ! ATTRS-SVE-128-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
 ! ATTRS-SVE-128-DAG: vscale_range(1,1)
+! ATTRS-SVE-128+: attributes #{{[0-9]+}}
+! ATTRS-SVE-128+-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-128+-DAG: vscale_range(1,0)
 ! ATTRS-SVE-256: attributes #{{[0-9]+}}
 ! ATTRS-SVE-256-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
 ! ATTRS-SVE-256-DAG: vscale_range(2,2)
+! ATTRS-SVE-256+: attributes #{{[0-9]+}}
+! ATTRS-SVE-256+-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve"
+! ATTRS-SVE-256+-DAG: vscale_range(2,0)
 ! ATTRS-SVE2-512: attributes #{{[0-9]+}}
 ! ATTRS-SVE2-512-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
 ! ATTRS-SVE2-512-DAG: vscale_range(4,4)
+! ATTRS-SVE2-512+: attributes #{{[0-9]+}}
+! ATTRS-SVE2-512+-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
+! ATTRS-SVE2-512+-DAG: vscale_range(4,0)
 ! ATTRS-SVE2SHA3-2048: attributes #{{[0-9]+}}
 ! ATTRS-SVE2SHA3-2048-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
 ! ATTRS-SVE2SHA3-2048-DAG: vscale_range(16,16)
+! ATTRS-SVE2SHA3-2048+: attributes #{{[0-9]+}}
+! ATTRS-SVE2SHA3-2048+-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2-sha3,+sve,+sve2"
+! ATTRS-SVE2SHA3-2048+-DAG: vscale_range(16,0)
 ! ATTRS-SVE2-SCALABLE: attributes #{{[0-9]+}}
 ! ATTRS-SVE2-SCALABLE-DAG: "target-features"="+neon{{(,\+v8a)*}},+sve2,+sve"
 ! ATTRS-SVE2-SCALABLE-DAG: vscale_range(1,16)

--- a/tools/flang2/flang2exe/cgmain.cpp
+++ b/tools/flang2/flang2exe/cgmain.cpp
@@ -13231,7 +13231,7 @@ write_target_features(void)
 INLINE static void
 write_vscale_range(void)
 {
-  if (flg.vscale_range_min && flg.vscale_range_max) {
+  if (flg.vscale_range_min) {
     char vsrange[64U];
     snprintf(vsrange, sizeof vsrange, " vscale_range(%d,%d)",
                                       flg.vscale_range_min,


### PR DESCRIPTION
The value 0 can be used as the maximum of the vscale_range attribute, which means unbounded.